### PR TITLE
fix: `Show full results` link was not visible in webkit browsers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,8 +16,9 @@ const pwaConfig = {
 }
 
 const innerConfig = Object.assign({}, nextConfig, pwaConfig)
-
 const withPWA = require('next-pwa')
-const nextConfigWithPWA = withPWA(innerConfig)
 
-module.exports = nextConfigWithPWA
+// do not activate pwa in development environment
+const config = process.env.NODE_ENV !== 'development' ? withPWA(innerConfig) : nextConfig
+
+module.exports = config

--- a/ui/common/SearchBox.tsx
+++ b/ui/common/SearchBox.tsx
@@ -38,13 +38,13 @@ export const SearchBox: React.FC = () => {
               </Link>
             ))}
           </ul>
-          {query !== '' ? (
+          {query !== '' && (
             <Link href={`/s/${query}`}>
-              <button className="px-4 pt-4 h-6">Show full results</button>
+              <button className="mx-4 mt-4 h-6">Show full results</button>
             </Link>
-          ) : null}
+          )}
           <Link href={`/o/cb`}>
-            <button className="px-4 h-6">Create new board</button>
+            <button className="mx-4 h-6">Create new board</button>
           </Link>
         </div>
       ) : null}


### PR DESCRIPTION
resolves #86 

Checked with Safari on Mac Monterey 12.4.

After:
<img width="1215" alt="スクリーンショット 2022-08-25 12 12 46" src="https://user-images.githubusercontent.com/33177050/186566060-eb6c6ac1-9859-480a-a88e-5083e4c07417.png">

Before:
<img width="1209" alt="スクリーンショット 2022-08-25 12 14 12" src="https://user-images.githubusercontent.com/33177050/186566182-4ec36a5a-35be-4432-917a-3845adbedd6a.png">

