### PR TITLE
Path exports from root, instead of using relative path

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  content: ["./ui/**/*.{ts,tsx}", "./pages/**/*.{ts,tsx}"],
+  //content: ["./ui/**/*.{ts,tsx}", "./pages/**/*.{ts,tsx}"],
+  content: ["ui/**/*.{ts,tsx}", "pages/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Fixes issue (maybe unique to Windows) with styles not loading when exporting to relative paths.