### PR TITLE
Desktop board styling updates (description and buttons)

### DIFF
--- a/ui/board/Board.tsx
+++ b/ui/board/Board.tsx
@@ -16,7 +16,7 @@ type BoardProps = {
 
 const FollowButton: React.FC<{ onClick: React.MouseEventHandler }> = ({ onClick }) => (
   <WithPrimaryButtonStyling>
-    <button onClick={onClick} className="flex block">
+    <button onClick={onClick} className="flex block py-2 -my-2 px-2 -mx-2 md:px-4 md:-mx-4 lg:px-6 lg:-mx-6">
       <PlusCircleIcon width={24} />
       <span className="px-2">Follow</span>
     </button>
@@ -25,7 +25,7 @@ const FollowButton: React.FC<{ onClick: React.MouseEventHandler }> = ({ onClick 
 
 const UnfollowButton: React.FC<{ onClick: React.MouseEventHandler }> = ({ onClick }) => (
   <WithPrimaryButtonStyling>
-    <button onClick={onClick} className="flex block">
+    <button onClick={onClick} className="flex block py-2 -my-2 px-2 -mx-2 md:px-4 md:-mx-4 lg:px-6 lg:-mx-6">
       <MinusCircleIcon width={24} />
       <span className="px-2">Unfollow</span>
     </button>
@@ -44,6 +44,9 @@ export const Board: React.FC<BoardProps> = observer(
               <span className="cursor-pointer">#{state.title}</span>
             </Link>
           </h1>
+          <div>
+            <MultiLineText text={state.description} />
+          </div>
           <div className={'flex ml-auto'}>
             {onFollowButtonClick ? (
               followButtonType === 'follow' ? (
@@ -55,7 +58,7 @@ export const Board: React.FC<BoardProps> = observer(
             {showPostCreate ? (
               <WithPrimaryButtonStyling>
                 <Link href={{ pathname: `/o/cp`, query: { boardId: state.id } }}>
-                  <button className="flex block">
+                  <button className="flex block py-2 -my-2 px-2 -mx-2 md:px-4 md:-mx-4 lg:px-6 lg:-mx-6">
                     <ChatIcon width={24} />
                     <span className="px-2">New Post</span>
                   </button>
@@ -63,9 +66,6 @@ export const Board: React.FC<BoardProps> = observer(
               </WithPrimaryButtonStyling>
             ) : null}
           </div>
-        </div>
-        <div>
-          <MultiLineText text={state.description} />
         </div>
         <ul>
           {state.posts.map((p, idx) => (

--- a/ui/common/Primitives.tsx
+++ b/ui/common/Primitives.tsx
@@ -20,7 +20,7 @@ export const WithPrimaryButtonStyling: React.FC = ({ children }) => {
   return (
     <div
       className={
-        'mb-4 py-2 px-2 md:px-4 lg:px-6 block text-white hover:bg-primary-dark rounded-xl border border-slate-300 bg-primary'
+        'mb-4 py-2 px-2 md:px-4 ml-2 lg:px-6 block text-white hover:bg-primary-dark rounded-xl border border-slate-300 bg-primary transition-colors'
       }
     >
       {children}


### PR DESCRIPTION
- Moved board description to below title (instead of below buttons)
- Made entire button clickable (not just text and icon) 
  - Added padding to inner button to extend clickable area, then shrunk to fit button size using negative margin. Did it this way so I didn't have to refactor/remove "WithPrimaryButtonStyling" component
- Added margin between follow & new post buttons
- Added transition-colors to buttons (fade bg color on hover)